### PR TITLE
Added DynamicallyAccessedMembers metadata

### DIFF
--- a/src/Spectre.Console.Cli/AsyncCommandOfT.cs
+++ b/src/Spectre.Console.Cli/AsyncCommandOfT.cs
@@ -4,7 +4,7 @@ namespace Spectre.Console.Cli;
 /// Base class for an asynchronous command.
 /// </summary>
 /// <typeparam name="TSettings">The settings type.</typeparam>
-public abstract class AsyncCommand<TSettings> : ICommand<TSettings>
+public abstract class AsyncCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TSettings> : ICommand<TSettings>
     where TSettings : CommandSettings
 {
     /// <summary>

--- a/src/Spectre.Console.Cli/CommandOfT.cs
+++ b/src/Spectre.Console.Cli/CommandOfT.cs
@@ -5,7 +5,7 @@ namespace Spectre.Console.Cli;
 /// </summary>
 /// <typeparam name="TSettings">The settings type.</typeparam>
 /// <seealso cref="AsyncCommand{TSettings}"/>
-public abstract class Command<TSettings> : ICommand<TSettings>
+public abstract class Command<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TSettings> : ICommand<TSettings>
     where TSettings : CommandSettings
 {
     /// <summary>

--- a/src/Spectre.Console.Cli/IConfigurator.cs
+++ b/src/Spectre.Console.Cli/IConfigurator.cs
@@ -38,7 +38,7 @@ public interface IConfigurator
     /// <typeparam name="TCommand">The command type.</typeparam>
     /// <param name="name">The name of the command.</param>
     /// <returns>A command configurator that can be used to configure the command further.</returns>
-    ICommandConfigurator AddCommand<TCommand>(string name)
+    ICommandConfigurator AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCommand>(string name)
         where TCommand : class, ICommand;
 
     /// <summary>

--- a/src/Spectre.Console.Cli/IConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/IConfiguratorOfT.cs
@@ -4,7 +4,7 @@ namespace Spectre.Console.Cli;
 /// Represents a configurator for specific settings.
 /// </summary>
 /// <typeparam name="TSettings">The command setting type.</typeparam>
-public interface IConfigurator<in TSettings>
+public interface IConfigurator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] in TSettings>
     where TSettings : CommandSettings
 {
     /// <summary>
@@ -44,7 +44,7 @@ public interface IConfigurator<in TSettings>
     /// <typeparam name="TCommand">The command type.</typeparam>
     /// <param name="name">The name of the command.</param>
     /// <returns>A command configurator that can be used to configure the command further.</returns>
-    ICommandConfigurator AddCommand<TCommand>(string name)
+    ICommandConfigurator AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCommand>(string name)
         where TCommand : class, ICommandLimiter<TSettings>;
 
     /// <summary>

--- a/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
@@ -49,7 +49,7 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
         return DefaultCommand;
     }
 
-    public ICommandConfigurator AddCommand<TCommand>(string name)
+    public ICommandConfigurator AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCommand>(string name)
         where TCommand : class, ICommand
     {
         var command = Commands.AddAndReturn(ConfiguredCommand.FromType<TCommand>(name, isDefaultCommand: false));

--- a/src/Spectre.Console.Cli/Internal/Configuration/ConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/ConfiguratorOfT.cs
@@ -1,6 +1,6 @@
 namespace Spectre.Console.Cli;
 
-internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConfigurator<TSettings>
+internal sealed class Configurator<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] TSettings> : IUnsafeBranchConfigurator, IConfigurator<TSettings>
     where TSettings : CommandSettings
 {
     private readonly ConfiguredCommand _command;
@@ -36,7 +36,7 @@ internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConf
         _command.IsHidden = true;
     }
 
-    public ICommandConfigurator AddCommand<TCommand>(string name)
+    public ICommandConfigurator AddCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCommand>(string name)
         where TCommand : class, ICommandLimiter<TSettings>
     {
         var command = ConfiguredCommand.FromType<TCommand>(name, isDefaultCommand: false);


### PR DESCRIPTION
Purely nice to have, added DynamicallyAccessedMembers metadata to remove the `Class 'x' is never instantiated` diagnostic is supressed