### PR TITLE
Lift restrictions on command option names

### DIFF
--- a/src/Spectre.Console.Cli.Tests/CommandOptionAttributeTests.Rendering.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandOptionAttributeTests.Rendering.cs
@@ -87,27 +87,6 @@ public sealed partial class CommandOptionAttributeTests
         }
     }
 
-    public sealed class InvalidCharacterInOptionName
-    {
-        public sealed class Settings : CommandSettings
-        {
-            [CommandOption("--f$oo")]
-            public string Foo { get; set; } = null!;
-        }
-
-        [Fact]
-        [Expectation("InvalidCharacterInOptionName")]
-        public Task Should_Return_Correct_Text()
-        {
-            // Given, When
-            var result = Fixture.Run<Settings>();
-
-            // Then
-            result.Exception.Message.ShouldBe("Encountered invalid character '$' in option name.");
-            return Verifier.Verify(result.Output);
-        }
-    }
-
     public sealed class LongOptionMustHaveMoreThanOneCharacter
     {
         public sealed class Settings : CommandSettings
@@ -167,27 +146,6 @@ public sealed partial class CommandOptionAttributeTests
 
             // Then
             result.Exception.Message.ShouldBe("Multiple option values are not supported.");
-            return Verifier.Verify(result.Output);
-        }
-    }
-
-    public sealed class InvalidCharacterInValueName
-    {
-        public sealed class Settings : CommandSettings
-        {
-            [CommandOption("-f|--foo <F$OO>")]
-            public string Foo { get; set; } = null!;
-        }
-
-        [Fact]
-        [Expectation("InvalidCharacterInValueName")]
-        public Task Should_Return_Correct_Text()
-        {
-            // Given, When
-            var result = Fixture.Run<Settings>();
-
-            // Then
-            result.Exception.Message.ShouldBe("Encountered invalid character '$' in value name.");
             return Verifier.Verify(result.Output);
         }
     }

--- a/src/Spectre.Console.Cli.Tests/CommandOptionAttributeTests.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandOptionAttributeTests.cs
@@ -107,23 +107,6 @@ public sealed partial class CommandOptionAttributeTests
     }
 
     [Theory]
-    [InlineData("--foo|-foo[b", '[')]
-    [InlineData("--foo|-f€b", '€')]
-    [InlineData("--foo|-foo@b", '@')]
-    public void Should_Throw_If_Option_Contains_Invalid_Name(string template, char invalid)
-    {
-        // Given, When
-        var result = Record.Exception(() => new CommandOptionAttribute(template));
-
-        // Then
-        result.ShouldBeOfType<CommandTemplateException>().And(e =>
-        {
-            e.Message.ShouldBe($"Encountered invalid character '{invalid}' in option name.");
-            e.Template.ShouldBe(template);
-        });
-    }
-
-    [Theory]
     [InlineData("--foo <HELLO-WORLD>", "HELLO-WORLD")]
     [InlineData("--foo <HELLO_WORLD>", "HELLO_WORLD")]
     public void Should_Accept_Dash_And_Underscore_In_Value_Name(string template, string name)

--- a/src/Spectre.Console.Cli.Tests/Expectations/Arguments/InvalidCharacterInOptionName.Output.verified.txt
+++ b/src/Spectre.Console.Cli.Tests/Expectations/Arguments/InvalidCharacterInOptionName.Output.verified.txt
@@ -1,5 +1,0 @@
-Error: An error occured when parsing template.
-       Encountered invalid character '$' in option name.
-
-       --f$oo
-          ^ Invalid character

--- a/src/Spectre.Console.Cli.Tests/Expectations/Arguments/InvalidCharacterInValueName.Output.verified.txt
+++ b/src/Spectre.Console.Cli.Tests/Expectations/Arguments/InvalidCharacterInValueName.Output.verified.txt
@@ -1,5 +1,0 @@
-Error: An error occured when parsing template.
-       Encountered invalid character '$' in value name.
-
-       -f|--foo <F$OO>
-                  ^ Invalid character

--- a/src/Spectre.Console.Cli/CommandTemplateException.cs
+++ b/src/Spectre.Console.Cli/CommandTemplateException.cs
@@ -77,22 +77,6 @@ public sealed class CommandTemplateException : CommandConfigurationException
             "Invalid option name.");
     }
 
-    internal static CommandTemplateException InvalidCharacterInOptionName(string template, TemplateToken token, char character)
-    {
-        // Rewrite the token to point to the invalid character instead of the whole value.
-        var position = (token.TokenKind == TemplateToken.Kind.ShortName
-            ? token.Position + 1
-            : token.Position + 2) + token.Value.OrdinalIndexOf(character);
-
-        token = new TemplateToken(
-            token.TokenKind, position,
-            token.Value, character.ToString(CultureInfo.InvariantCulture));
-
-        return CommandLineTemplateExceptionFactory.Create(template, token,
-            $"Encountered invalid character '{character}' in option name.",
-            "Invalid character.");
-    }
-
     internal static CommandTemplateException LongOptionMustHaveMoreThanOneCharacter(string template, TemplateToken token)
     {
         // Rewrite the token to point to the option name instead of the whole option.
@@ -125,19 +109,6 @@ public sealed class CommandTemplateException : CommandConfigurationException
         return CommandLineTemplateExceptionFactory.Create(template, token,
             "Multiple option values are not supported.",
             "Too many option values.");
-    }
-
-    internal static CommandTemplateException InvalidCharacterInValueName(string template, TemplateToken token, char character)
-    {
-        // Rewrite the token to point to the invalid character instead of the whole value.
-        token = new TemplateToken(
-            token.TokenKind,
-            token.Position + 1 + token.Value.OrdinalIndexOf(character),
-            token.Value, character.ToString(CultureInfo.InvariantCulture));
-
-        return CommandLineTemplateExceptionFactory.Create(template, token,
-            $"Encountered invalid character '{character}' in value name.",
-            "Invalid character.");
     }
 
     internal static CommandTemplateException MissingLongAndShortName(string template, TemplateToken? token)

--- a/src/Spectre.Console.Cli/Internal/Configuration/TemplateParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/TemplateParser.cs
@@ -77,14 +77,6 @@ internal static class TemplateParser
                 {
                     throw CommandTemplateException.OptionNamesCannotStartWithDigit(template, token);
                 }
-
-                foreach (var character in token.Value)
-                {
-                    if (!char.IsLetterOrDigit(character) && character != '-' && character != '_' && character != '?')
-                    {
-                        throw CommandTemplateException.InvalidCharacterInOptionName(template, token, character);
-                    }
-                }
             }
 
             if (token.TokenKind == TemplateToken.Kind.LongName)
@@ -113,15 +105,6 @@ internal static class TemplateParser
                 if (!string.IsNullOrWhiteSpace(result.Value))
                 {
                     throw CommandTemplateException.MultipleOptionValuesAreNotSupported(template, token);
-                }
-
-                foreach (var character in token.Value)
-                {
-                    if (!char.IsLetterOrDigit(character) &&
-                        character != '=' && character != '-' && character != '_' && character != '|')
-                    {
-                        throw CommandTemplateException.InvalidCharacterInValueName(template, token, character);
-                    }
                 }
 
                 result.Value = token.Value.ToUpperInvariant();


### PR DESCRIPTION
Before:
* [CommandOption("-f|--foo <F$OO>")] is invalid and throws CommandTemplateException
* [CommandOption("--f$oo")] is invalid and throws CommandTemplateException

After:
* [CommandOption("-f|--foo <F$OO>")] is valid
* [CommandOption("--f$oo")] is valid

As discussed in #8