### PR TITLE
Fix pair deconstruction with default values

### DIFF
--- a/src/Spectre.Console.Cli.Tests/CommandAppTests.Pairs.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandAppTests.Pairs.cs
@@ -52,6 +52,13 @@ public sealed partial class CommandAppTests
             public IReadOnlyDictionary<string, string>? Values { get; set; }
         }
 
+        public sealed class DefaultValuesSettings : CommandSettings
+        {
+            [CommandOption("--var <VALUE>")]
+            [DefaultValue(new[] { "Monday=1", "Tuesday=2" })]
+            public IReadOnlyDictionary<DayOfWeek, int>? Values { get; set; }
+        }
+
         public sealed class StringIntDeconstructor : PairDeconstructor<string, string>
         {
             protected override (string Key, string Value) Deconstruct(string? value)
@@ -310,6 +317,31 @@ public sealed partial class CommandAppTests
                 pair.Values.Count.ShouldBe(2);
                 pair.Values["foo"].ShouldBe("bar");
                 pair.Values["baz"].ShouldBe("qux");
+            });
+        }
+
+        [Fact]
+        public void Should_Map_Default_Values()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.SetDefaultCommand<GenericCommand<DefaultValuesSettings>>();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+            });
+
+            // When
+            var result = app.Run();
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<DefaultValuesSettings>().And(pair =>
+            {
+                pair.Values.ShouldNotBeNull();
+                pair.Values.Count.ShouldBe(2);
+                pair.Values[DayOfWeek.Monday].ShouldBe(1);
+                pair.Values[DayOfWeek.Tuesday].ShouldBe(2);
             });
         }
     }

--- a/src/Spectre.Console.Cli/Internal/Binding/CommandValueBinder.cs
+++ b/src/Spectre.Console.Cli/Internal/Binding/CommandValueBinder.cs
@@ -54,10 +54,13 @@ internal sealed class CommandValueBinder
         }
 
         // Deconstruct and add to multimap.
-        var pair = deconstructor.Deconstruct(resolver, genericTypes[0], genericTypes[1], value as string);
-        if (pair.Key != null)
+        foreach (var text in value as IEnumerable<string?> ?? [ value as string ])
         {
-            multimap.Add(pair);
+            var pair = deconstructor.Deconstruct(resolver, genericTypes[0], genericTypes[1], text);
+            if (pair.Key != null)
+            {
+                multimap.Add(pair);
+            }
         }
 
         return multimap;


### PR DESCRIPTION
Fixes #75

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console.cli/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes

Handling both IEnumerable&lt;string&gt; and string when deconstructing pairs, covered by a new test.

---
Please upvote :+1: this pull request if you are interested in it.