### PR TITLE
Fix erroneous missing required option error message

### DIFF
--- a/src/Spectre.Console.Cli.Tests/CommandAppTests.Options.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandAppTests.Options.cs
@@ -21,7 +21,7 @@ public sealed partial class CommandAppTests
             // Then
             result.ShouldBeOfType<CommandRuntimeException>()
                 .And(ex =>
-                    ex.Message.ShouldBe("Command 'test' is missing required argument 'foo'."));
+                    ex.Message.ShouldBe("Command 'test' is missing required option 'foo'."));
         }
     }
 }

--- a/src/Spectre.Console.Cli/CommandRuntimeException.cs
+++ b/src/Spectre.Console.Cli/CommandRuntimeException.cs
@@ -44,7 +44,7 @@ public class CommandRuntimeException : CommandAppException
             return new CommandRuntimeException($"Missing required option '{option.GetOptionName()}'.");
         }
 
-        return new CommandRuntimeException($"Command '{node.Command.Name}' is missing required argument '{option.GetOptionName()}'.");
+        return new CommandRuntimeException($"Command '{node.Command.Name}' is missing required option '{option.GetOptionName()}'.");
     }
 
     internal static CommandRuntimeException NoConverterFound(CommandParameter parameter)


### PR DESCRIPTION
Probably a copy/paste error since the messages for the default command (3 lines above) say "Missing required option" vs "Missing required argument"