### PR TITLE
Ensure that "The value '…' is not in a correct format" ends with a new line

### DIFF
--- a/src/Spectre.Console.Cli.Tests/CommandAppTests.Pairs.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandAppTests.Pairs.cs
@@ -192,7 +192,7 @@ public sealed partial class CommandAppTests
             string input, string expected)
         {
             // Given
-            var app = new CommandAppTester();
+            var app = new CommandAppTester { TestSettings = { TrimConsoleOutput = false } };
             app.SetDefaultCommand<GenericCommand<DefaultPairDeconstructorSettings>>();
 
             // When
@@ -203,7 +203,7 @@ public sealed partial class CommandAppTests
 
             // Then
             result.ExitCode.ShouldBe(-1);
-            result.Output.ShouldBe(expected);
+            result.Output.ShouldBe(expected + Environment.NewLine);
         }
 
         [Fact]

--- a/src/Spectre.Console.Cli/CommandParseException.cs
+++ b/src/Spectre.Console.Cli/CommandParseException.cs
@@ -110,7 +110,7 @@ public sealed class CommandParseException : CommandRuntimeException
 
     internal static CommandParseException ValueIsNotInValidFormat(string value)
     {
-        var text = $"[red]Error:[/] The value '[white]{value}[/]' is not in a correct format";
+        var text = $"[red]Error:[/] The value '[white]{value}[/]' is not in a correct format{Environment.NewLine}";
         return new CommandParseException("Could not parse value", new Markup(text));
     }
 


### PR DESCRIPTION
It's weird when an error message doesn't have a newline in a CLI app.

Note that all other `CommandParseException` exceptions created through `CommandLineParseExceptionFactory` are properly ended with a new line.