### PR TITLE
Fix visibility of Validate and Execute(Async) methods of commands

### DIFF
--- a/src/Spectre.Console.Cli.Tests/CommandAppTests.Constructor.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandAppTests.Constructor.cs
@@ -28,12 +28,12 @@ public sealed partial class CommandAppTests
 
     public class NullableCommand : Command<NullableSettings>
     {
-        protected override int Execute(CommandContext context, NullableSettings settings, CancellationToken cancellationToken) => 0;
+        public override int Execute(CommandContext context, NullableSettings settings, CancellationToken cancellationToken) => 0;
     }
 
     public class NullableWithInitCommand : Command<NullableWithInitSettings>
     {
-        protected override int Execute(CommandContext context, NullableWithInitSettings settings, CancellationToken cancellationToken) => 0;
+        public override int Execute(CommandContext context, NullableWithInitSettings settings, CancellationToken cancellationToken) => 0;
     }
 
     [Fact]

--- a/src/Spectre.Console.Cli.Tests/CommandAppTests.Injection.Settings.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandAppTests.Injection.Settings.cs
@@ -19,7 +19,7 @@ public sealed partial class CommandAppTests
                     _dep = dep;
                 }
 
-                protected override int Execute(CommandContext context, CustomInheritedCommandSettings settings, CancellationToken cancellationToken)
+                public override int Execute(CommandContext context, CustomInheritedCommandSettings settings, CancellationToken cancellationToken)
                 {
                     return _dep.GetExitCode();
                 }

--- a/src/Spectre.Console.Cli.Tests/CommandAppTests.Interceptor.cs
+++ b/src/Spectre.Console.Cli.Tests/CommandAppTests.Interceptor.cs
@@ -10,7 +10,7 @@ public sealed partial class CommandAppTests
             {
             }
 
-            protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+            public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
             {
                 return 0;
             }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/AsynchronousCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/AsynchronousCommand.cs
@@ -9,7 +9,7 @@ public sealed class AsynchronousCommand : AsyncCommand<AsynchronousCommandSettin
         _console = console;
     }
 
-    protected override async Task<int> ExecuteAsync(CommandContext context, AsynchronousCommandSettings settings, CancellationToken cancellationToken)
+    public override async Task<int> ExecuteAsync(CommandContext context, AsynchronousCommandSettings settings, CancellationToken cancellationToken)
     {
         // Simulate a long running asynchronous task
         await Task.Delay(200, cancellationToken);

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/CatCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/CatCommand.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Data;
 
 public class CatCommand : AnimalCommand<CatSettings>
 {
-    protected override int Execute(CommandContext context, CatSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, CatSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/DogCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/DogCommand.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Data;
 [Description("The dog command.")]
 public class DogCommand : AnimalCommand<DogSettings>
 {
-    protected override ValidationResult Validate(CommandContext context, DogSettings settings)
+    public override ValidationResult Validate(CommandContext context, DogSettings settings)
     {
         if (context is null)
         {
@@ -23,7 +23,7 @@ public class DogCommand : AnimalCommand<DogSettings>
         return base.Validate(context, settings);
     }
 
-    protected override int Execute(CommandContext context, DogSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, DogSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/DumpRemainingCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/DumpRemainingCommand.cs
@@ -9,7 +9,7 @@ public sealed class DumpRemainingCommand : Command<EmptyCommandSettings>
         _console = console;
     }
 
-    protected override int Execute(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)
     {
         if (context.Remaining.Raw.Count > 0)
         {

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/EmptyCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/EmptyCommand.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Data;
 
 public sealed class EmptyCommand : Command<EmptyCommandSettings>
 {
-    protected override int Execute(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/GenericCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/GenericCommand.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Data;
 public sealed class GenericCommand<TSettings> : Command<TSettings>
     where TSettings : CommandSettings
 {
-    protected override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/GiraffeCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/GiraffeCommand.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Data;
 [Description("The giraffe command.")]
 public sealed class GiraffeCommand : Command<GiraffeSettings>
 {
-    protected override int Execute(CommandContext context, GiraffeSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, GiraffeSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/GreeterCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/GreeterCommand.cs
@@ -9,7 +9,7 @@ public class GreeterCommand : Command<OptionalArgumentWithDefaultValueSettings>
         _console = console;
     }
 
-    protected override int Execute(CommandContext context, OptionalArgumentWithDefaultValueSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, OptionalArgumentWithDefaultValueSettings settings, CancellationToken cancellationToken)
     {
         _console.WriteLine(settings.Greeting ?? string.Empty);
         return 0;

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/HiddenOptionsCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/HiddenOptionsCommand.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Data;
 
 public sealed class HiddenOptionsCommand : Command<HiddenOptionSettings>
 {
-    protected override int Execute(CommandContext context, HiddenOptionSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, HiddenOptionSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/HorseCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/HorseCommand.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Data;
 [Description("The horse command.")]
 public class HorseCommand : AnimalCommand<HorseSettings>
 {
-    protected override int Execute(CommandContext context, HorseSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, HorseSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/InvalidCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/InvalidCommand.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Data;
 
 public sealed class InvalidCommand : Command<InvalidSettings>
 {
-    protected override int Execute(CommandContext context, InvalidSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, InvalidSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/LionCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/LionCommand.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Data;
 [Description("The lion command.")]
 public class LionCommand : AnimalCommand<LionSettings>
 {
-    protected override int Execute(CommandContext context, LionSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, LionSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/NoDescriptionCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/NoDescriptionCommand.cs
@@ -5,7 +5,7 @@ public sealed class NoDescriptionCommand : Command<EmptyCommandSettings>
     [CommandOption("-f|--foo <VALUE>")]
     public int Foo { get; set; }
 
-    protected override int Execute(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/OptionVectorCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/OptionVectorCommand.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Data;
 
 public class OptionVectorCommand : Command<OptionVectorSettings>
 {
-    protected override int Execute(CommandContext context, OptionVectorSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, OptionVectorSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/ThrowingCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/ThrowingCommand.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Data;
 
 public sealed class ThrowingCommand : Command<ThrowingCommandSettings>
 {
-    protected override int Execute(CommandContext context, ThrowingCommandSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, ThrowingCommandSettings settings, CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("W00t?");
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/TurtleCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/TurtleCommand.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Data;
 [Description("The turtle command.")]
 public class TurtleCommand : AnimalCommand<TurtleSettings>
 {
-    protected override int Execute(CommandContext context, TurtleSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, TurtleSettings settings, CancellationToken cancellationToken)
     {
         return 0;
     }

--- a/src/Spectre.Console.Cli.Tests/Data/Commands/VersionCommand.cs
+++ b/src/Spectre.Console.Cli.Tests/Data/Commands/VersionCommand.cs
@@ -9,7 +9,7 @@ public sealed class VersionCommand : Command<VersionSettings>
         _console = console;
     }
 
-    protected override int Execute(CommandContext context, VersionSettings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, VersionSettings settings, CancellationToken cancellationToken)
     {
         _console.WriteLine($"VersionCommand ran, Version: {settings.Version ?? string.Empty}");
 

--- a/src/Spectre.Console.Cli/AsyncCommand.cs
+++ b/src/Spectre.Console.Cli/AsyncCommand.cs
@@ -11,7 +11,7 @@ public abstract class AsyncCommand : ICommand<EmptyCommandSettings>
     /// <param name="context">The command context.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to abort the command.</param>
     /// <returns>An integer indicating whether the command executed successfully.</returns>
-    protected abstract Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken);
+    public abstract Task<int> ExecuteAsync(CommandContext context, CancellationToken cancellationToken);
 
     /// <inheritdoc/>
     Task<int> ICommand<EmptyCommandSettings>.ExecuteAsync(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)

--- a/src/Spectre.Console.Cli/AsyncCommandOfT.cs
+++ b/src/Spectre.Console.Cli/AsyncCommandOfT.cs
@@ -13,7 +13,7 @@ public abstract class AsyncCommand<TSettings> : ICommand<TSettings>
     /// <param name="context">The command context.</param>
     /// <param name="settings">The settings.</param>
     /// <returns>The validation result.</returns>
-    protected virtual ValidationResult Validate(CommandContext context, TSettings settings)
+    public virtual ValidationResult Validate(CommandContext context, TSettings settings)
     {
         return ValidationResult.Success();
     }
@@ -25,7 +25,7 @@ public abstract class AsyncCommand<TSettings> : ICommand<TSettings>
     /// <param name="settings">The settings.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to abort the command.</param>
     /// <returns>An integer indicating whether or not the command executed successfully.</returns>
-    protected abstract Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken);
+    public abstract Task<int> ExecuteAsync(CommandContext context, TSettings settings, CancellationToken cancellationToken);
 
     /// <inheritdoc/>
     ValidationResult ICommand.Validate(CommandContext context, CommandSettings settings)

--- a/src/Spectre.Console.Cli/Command.cs
+++ b/src/Spectre.Console.Cli/Command.cs
@@ -12,7 +12,7 @@ public abstract class Command : ICommand<EmptyCommandSettings>
     /// <param name="context">The command context.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to abort the command.</param>
     /// <returns>An integer indicating whether the command executed successfully.</returns>
-    protected abstract int Execute(CommandContext context, CancellationToken cancellationToken);
+    public abstract int Execute(CommandContext context, CancellationToken cancellationToken);
 
     /// <inheritdoc/>
     Task<int> ICommand<EmptyCommandSettings>.ExecuteAsync(CommandContext context, EmptyCommandSettings settings, CancellationToken cancellationToken)

--- a/src/Spectre.Console.Cli/CommandOfT.cs
+++ b/src/Spectre.Console.Cli/CommandOfT.cs
@@ -14,7 +14,7 @@ public abstract class Command<TSettings> : ICommand<TSettings>
     /// <param name="context">The command context.</param>
     /// <param name="settings">The settings.</param>
     /// <returns>The validation result.</returns>
-    protected virtual ValidationResult Validate(CommandContext context, TSettings settings)
+    public virtual ValidationResult Validate(CommandContext context, TSettings settings)
     {
         return ValidationResult.Success();
     }
@@ -26,7 +26,7 @@ public abstract class Command<TSettings> : ICommand<TSettings>
     /// <param name="settings">The settings.</param>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can be used to abort the command.</param>
     /// <returns>An integer indicating whether the command executed successfully.</returns>
-    protected abstract int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken);
+    public abstract int Execute(CommandContext context, TSettings settings, CancellationToken cancellationToken);
 
     /// <inheritdoc/>
     ValidationResult ICommand.Validate(CommandContext context, CommandSettings settings)

--- a/src/Spectre.Console.Cli/Internal/Commands/ExplainCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/ExplainCommand.cs
@@ -27,7 +27,7 @@ internal sealed class ExplainCommand : Command<ExplainCommand.Settings>, IBuiltI
         public bool IncludeHidden { get; set; }
     }
 
-    protected override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         var tree = new Tree("CLI Configuration");
         tree.AddNode(ValueMarkup("Application Name", _commandModel.ApplicationName, "no application name"));

--- a/src/Spectre.Console.Cli/Internal/Commands/OpenCliGeneratorCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/OpenCliGeneratorCommand.cs
@@ -13,7 +13,7 @@ internal sealed class OpenCliGeneratorCommand : Command, IBuiltInCommand
         _model = model ?? throw new ArgumentNullException(nameof(model));
     }
 
-    protected override int Execute(CommandContext context, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, CancellationToken cancellationToken)
     {
         var document = new OpenCliDocument
         {

--- a/src/Spectre.Console.Cli/Internal/Commands/VersionCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/VersionCommand.cs
@@ -11,7 +11,7 @@ internal sealed class VersionCommand : Command, IBuiltInCommand
         _writer = configuration.Settings.Console.GetConsole();
     }
 
-    protected override int Execute(CommandContext context, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, CancellationToken cancellationToken)
     {
         _writer.MarkupLine(
             "[yellow]Spectre.Console.Cli[/] version [aqua]{0}[/]",

--- a/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
@@ -13,7 +13,7 @@ internal sealed class XmlDocCommand : Command, IBuiltInCommand
         _writer = configuration.Settings.Console.GetConsole();
     }
 
-    protected override int Execute(CommandContext context, CancellationToken cancellationToken)
+    public override int Execute(CommandContext context, CancellationToken cancellationToken)
     {
         _writer.Write(Serialize(_model), Style.Plain);
         return 0;


### PR DESCRIPTION
Change it back to public instead of protected. Was probably a bad merge in c2b92acb2bbea5864128167623da18a08ae7e4fd.

Fixes #73